### PR TITLE
Windows Fix

### DIFF
--- a/core/ParquetTypes.hpp
+++ b/core/ParquetTypes.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <string>
-
+#if defined(_WIN32) && defined(OPTIONAL)
+#undef OPTIONAL
+#endif
 namespace clearParquet {
 
 struct Compression {


### PR DESCRIPTION
Windows build fails because Windows cpp defines a macro "OPTIONAL" which interferes with the enum we have. Probably not the best way to handle but it work.